### PR TITLE
Remove redundant model load calls

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -11,10 +11,6 @@ class Home extends MY_Controller {
         $this->data['pagetitle'] = 'Home';
 		$this->data['pagebody'] = 'home';
 
-        $this->load->model("HomeModel");
-        $this->load->model("StockHistory");
-        $this->load->model("PortfolioModel");
-
         $stocks = $this->StockHistory->getStocks();
         $players = $this->PortfolioModel->getPlayers();
 


### PR DESCRIPTION
These models are loaded in the autoload config, so it's not necessary for these calls again.
